### PR TITLE
Isolate and improve environment variables

### DIFF
--- a/extra/config.toml
+++ b/extra/config.toml
@@ -38,6 +38,8 @@
 # ---------
 #
 
+tty = 2
+
 [power_options]
 # Allow for the shutdown option to be used
 allow_shutdown = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::{fs, process};
 use std::io::{self, BufReader, Read};
-use std::{fs, process};
 
 use crossterm::event::KeyCode;
 use log::error;
@@ -116,6 +115,7 @@ pub fn get_key(key: &str) -> KeyCode {
 
 #[derive(Deserialize)]
 pub struct Config {
+    pub tty: u8,
     pub power_options: PowerOptionsConfig,
     pub window_manager_selector: WMSelectorConfig,
     pub username_field: UsernameFieldConfig,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
-use std::{fs, process};
 use std::io::{self, BufReader, Read};
+use std::{fs, process};
 
 use crossterm::event::KeyCode;
 use log::error;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,45 @@
+use std::env;
+use log::{info, error};
+
+fn env_set_and_announce(key: &str, value: &str) {
+    env::set_var(key, value);
+    info!("Set environment variable '{}' to '{}'", key, value);
+}
+
+/// Set all the environment variables
+pub fn init_environment(username: &str, homedir: &str, shell: &str) {
+    env_set_and_announce("HOME", homedir);
+
+    let pwd = homedir;
+    if let Ok(_) = env::set_current_dir(pwd) {
+        info!("Successfully changed working directory to {}!", pwd);
+    } else {
+        error!("Failed to change the working directory to {}", pwd);
+    }
+
+    env_set_and_announce("SHELL", shell);
+    env_set_and_announce("USER", username);
+    env_set_and_announce("LOGNAME", username);
+    env_set_and_announce("PATH", "/usr/local/sbin:/usr/local/bin:/usr/bin");
+
+    // env::set_var("MAIL", "..."); TODO: Add
+}
+
+// NOTE: This uid: u32 might be better set to libc::uid_t
+/// Set the XDG environment variables
+pub fn set_xdg_env(uid: u32, homedir: &str, tty: u8) {
+    // This is according to https://wiki.archlinux.org/title/XDG_Base_Directory
+
+    env_set_and_announce("XDG_CONFIG_DIR", &format!("{}/.config", homedir));
+    env_set_and_announce("XDG_CACHE_HOME", &format!("{}/.cache", homedir));
+    env_set_and_announce("XDG_DATA_HOME", &format!("{}/.local/share", homedir));
+    env_set_and_announce("XDG_STATE_HOME", &format!("{}/.local/state", homedir));
+    env_set_and_announce("XDG_DATA_DIRS", "/usr/local/share:/usr/share");
+    env_set_and_announce("XDG_CONFIG_DIRS", "/etc/xdg");
+
+    env_set_and_announce("XDG_RUNTIME_DIR", &format!("/run/user/{}", uid));
+    env_set_and_announce("XDG_SESSION_DIR", "user");
+    env_set_and_announce("XDG_SESSION_ID", "1");
+    env_set_and_announce("XDG_SEAT", "seat0");
+    env_set_and_announce("XDG_VTNR", &tty.to_string());
+}

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,5 +1,5 @@
+use log::{error, info};
 use std::env;
-use log::{info, error};
 
 fn env_set_and_announce(key: &str, value: &str) {
     env::set_var(key, value);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ use clap::{arg, App as ClapApp};
 use log::{error, info};
 
 mod config;
+mod environment;
 mod graphical_environments;
 mod initrcs;
-mod environment;
 mod pam;
 mod ui;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use log::{error, info};
 mod config;
 mod graphical_environments;
 mod initrcs;
+mod environment;
 mod pam;
 mod ui;
 
@@ -54,7 +55,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     if !preview {
         // Switch to the proper tty
-        if chvt::chvt(2).is_err() {
+        if chvt::chvt(config.tty.into()).is_err() {
             error!("Failed to switch TTY");
         };
         info!("Successfully switched TTY");

--- a/src/pam.rs
+++ b/src/pam.rs
@@ -14,24 +14,6 @@ pub enum PamError {
     SessionOpen,
 }
 
-/// Set all the environment variables
-pub fn init_environment(passwd: &PasswdEntry) {
-    info!("Setting environment");
-
-    env::set_var("HOME", &passwd.dir);
-    let pwd = Path::new(&passwd.dir);
-    if let Ok(_) = env::set_current_dir(&pwd) {
-        info!("Successfully changed working directory to {}!", &passwd.dir);
-    } else {
-        error!("Failed to change the working directory to {}", &passwd.dir);
-    }
-    env::set_var("SHELL", &passwd.shell);
-    env::set_var("USER", &passwd.name);
-    env::set_var("LOGNAME", &passwd.name);
-    env::set_var("PATH", "/usr/local/sbin:/usr/local/bin:/usr/bin");
-    // env::set_var("MAIL", "..."); TODO: Add
-}
-
 /// Open a PAM authenticated session
 pub fn open_session<'a>(
     username: impl ToString,
@@ -65,9 +47,6 @@ pub fn open_session<'a>(
 
     // NOTE: Maybe we should also load all groups here
     let passwd_entry = get_entry_by_name(&username).ok_or(PamError::UsernameNotFound)?;
-
-    // Init environment for current TTY
-    init_environment(&passwd_entry);
 
     authenticator
         .open_session()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,9 +5,9 @@ use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
 
 use crate::config::Config;
+use crate::environment::{init_environment, set_xdg_env};
 use crate::graphical_environments::GraphicalEnvironment;
 use crate::pam::{open_session, PamError};
-use crate::environment::{init_environment, set_xdg_env};
 use crate::{initrcs, X};
 
 use crossterm::{


### PR DESCRIPTION
Add the XDG environment variables and isolate the setting of environment variables to their own module. The TTY is now also settable from the `config.toml`.

Closes #37