### PR TITLE
Switch arg parsing to clap-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,16 +83,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -100,15 +100,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -190,12 +199,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -389,13 +395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
+name = "once_cell"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "pam"
@@ -676,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ chvt = "0.2.0"
 rand = "0.8.4"
 chrono = "0.4"
 nix = "0.23.1"
-clap = { version = "3.0.0", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 hex = "0.4.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::{self, BufReader, Read};
+use std::path::Path;
 use std::process;
 
 use crossterm::event::KeyCode;
@@ -274,7 +275,7 @@ impl Default for Config {
 }
 
 impl PartialConfig {
-    pub fn from_file(path: &str) -> io::Result<PartialConfig> {
+    pub fn from_file(path: &Path) -> io::Result<PartialConfig> {
         let file = File::open(path)?;
         let mut buf_reader = BufReader::new(file);
         let mut contents = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 use std::io;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use std::process;
 
 use clap::Parser;
@@ -45,7 +45,8 @@ fn merge_in_configuration(config: &mut Config, config_path: Option<&Path>) {
             if let Some(config_path) = config_path {
                 eprintln!(
                     "The config file '{}' cannot be loaded.\nReason: {}",
-                    config_path.display(), err
+                    config_path.display(),
+                    err
                 );
                 process::exit(1);
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,10 @@
 
 use std::error::Error;
 use std::io;
+use std::path::{PathBuf, Path};
 use std::process;
 
-use clap::{arg, App as ClapApp};
+use clap::Parser;
 use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -27,14 +28,14 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/lemurs/config.toml";
 const PREVIEW_LOG_PATH: &str = "lemurs.log";
 const DEFAULT_LOG_PATH: &str = "/var/log/lemurs.log";
 
-fn merge_in_configuration(config: &mut Config, config_path: Option<&str>) {
-    let load_config_path = config_path.unwrap_or(DEFAULT_CONFIG_PATH);
+fn merge_in_configuration(config: &mut Config, config_path: Option<&Path>) {
+    let load_config_path = config_path.unwrap_or_else(|| Path::new(DEFAULT_CONFIG_PATH));
 
     match config::PartialConfig::from_file(load_config_path) {
         Ok(partial_config) => {
             info!(
                 "Successfully loaded configuration file from '{}'",
-                load_config_path
+                load_config_path.display()
             );
             config.merge_in_partial(partial_config)
         }
@@ -44,7 +45,7 @@ fn merge_in_configuration(config: &mut Config, config_path: Option<&str>) {
             if let Some(config_path) = config_path {
                 eprintln!(
                     "The config file '{}' cannot be loaded.\nReason: {}",
-                    config_path, err
+                    config_path.display(), err
                 );
                 process::exit(1);
             } else {
@@ -95,31 +96,35 @@ fn setup_logger(is_preview: bool) {
         });
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    let matches = ClapApp::new("Lemurs")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author(env!("CARGO_PKG_AUTHORS"))
-        .about(env!("CARGO_PKG_DESCRIPTION"))
-        .arg(arg!(--preview))
-        .arg(arg!(--nolog))
-        .arg(arg!(-c --config [FILE] "a file to replace the default configuration"))
-        .get_matches();
+#[derive(Parser)]
+#[clap(name = "Lemurs", about, author, version)]
+struct Cli {
+    #[clap(long)]
+    preview: bool,
 
-    let no_log = matches.is_present("nolog");
-    let preview = matches.is_present("preview");
+    #[clap(long)]
+    no_log: bool,
+
+    /// A file to replace the default configuration
+    #[clap(short, long, value_name = "FILE")]
+    config: Option<PathBuf>,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
 
     // Setup the logger
-    if !no_log {
-        setup_logger(preview);
+    if !cli.no_log {
+        setup_logger(cli.preview);
     }
 
     info!("Lemurs logger is running");
 
     // Load and setup configuration
     let mut config = Config::default();
-    merge_in_configuration(&mut config, matches.value_of("config"));
+    merge_in_configuration(&mut config, cli.config.as_deref());
 
-    if !preview {
+    if !cli.preview {
         // Switch to the proper tty
         info!("Switching to tty {}", config.tty);
 
@@ -130,7 +135,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Start application
     let mut terminal = tui_enable()?;
-    let login_form = ui::LoginForm::new(config, preview);
+    let login_form = ui::LoginForm::new(config, cli.preview);
     login_form.run(&mut terminal, try_auth, post_login_env_start)?;
     tui_disable(terminal)?;
 


### PR DESCRIPTION
Hi, I recently discovered this project and would love to have a proper TUI display manager in my leftwm config, so I thought I'd contribute.

This PR changes the clap API to the derive version, which should eliminate some boilerplate code.

Notable changes (to be adjusted/reverted at your discretion):
- switch around some function signatures to use `&Path` instead of raw `&str`
- rename `--nolog` flag to `--no-log` 