### PR TITLE
Enable building with stable toolchain

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ echo
 
 # Compile lemurs
 echo 'Step 1: Compile Lemurs'
-cargo +nightly build --release 
+cargo build --release 
 if [ $? -ne 0 ]; then exit 1; fi
 
 # Move lemurs to /usr/bin

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(setgroups)]
-
 use std::error::Error;
 use std::io;
 use std::path::{Path, PathBuf};

--- a/src/post_login/x.rs
+++ b/src/post_login/x.rs
@@ -129,7 +129,7 @@ pub fn start_env(user_info: &AuthUserInfo, script_path: &str) -> Result<Child, X
         .uid(uid)
         .gid(gid);
     let cmd =
-        unsafe { cmd.pre_exec(move || nix::unistd::setgroups(&groups).map_err(|err| err.into())) };
+        unsafe { cmd.pre_exec(move || nix::unistd::setgroups(&groups) }.map_err(|err| err.into()));
 
     let child = cmd.spawn().map_err(|err| {
         error!("Failed to start specified environment. Reason: {}", err);

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -393,14 +393,14 @@ mod tests {
         fn empty_creation() {
             // On an empty selector the go_next and go_prev should do nothing.
 
-            let mut selector = Switcher::new(vec![]);
+            let mut selector: Switcher<()> = Switcher::new(vec![]);
             assert_eq!(selector.current(), None);
             selector.go_next();
             assert_eq!(selector.current(), None);
             selector.go_prev();
             assert_eq!(selector.current(), None);
 
-            let mut selector = Switcher::new(vec![]);
+            let mut selector: Switcher<()> = Switcher::new(vec![]);
             assert_eq!(selector.current(), None);
             selector.go_prev();
             assert_eq!(selector.current(), None);
@@ -410,7 +410,7 @@ mod tests {
 
         #[test]
         fn single_creation() {
-            let wm = SwitcherItem::new("abc", "/abc".into());
+            let wm: SwitcherItem<String> = SwitcherItem::new("abc", "/abc".into());
 
             let mut selector = Switcher::new(vec![wm.clone()]);
             assert_eq!(selector.current(), Some(&wm));
@@ -443,7 +443,7 @@ mod tests {
 
         #[test]
         fn multiple_creation() {
-            let wm1 = SwitcherItem::new("abc", "/abc".into());
+            let wm1: SwitcherItem<String> = SwitcherItem::new("abc", "/abc".into());
             let wm2 = SwitcherItem::new("def", "/def".into());
 
             let mut selector = Switcher::new(vec![wm1.clone(), wm2.clone()]);


### PR DESCRIPTION
I noticed it's relatively easy to switch the nightly `groups()` call to `pre_exec(nix::unistd::setgroups(...))`, which is effectively what is done under the hood.

This allows us to use the stable toolchain while awaiting stabilization.

Also adjusted some tests that wouldn't compile on stable.