### PR TITLE
Add --tty CLI flag to override TTY configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,10 @@ struct Cli {
     #[clap(long)]
     no_log: bool,
 
+    /// Override the configured TTY number
+    #[clap(long, value_name = "N")]
+    tty: Option<u8>,
+
     /// A file to replace the default configuration
     #[clap(short, long, value_name = "FILE")]
     config: Option<PathBuf>,
@@ -165,6 +169,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Load and setup configuration
     let mut config = Config::default();
     merge_in_configuration(&mut config, cli.config.as_deref());
+
+    if let Some(tty) = cli.tty {
+        config.tty = tty;
+    }
 
     if !cli.preview {
         // Switch to the proper tty

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     merge_in_configuration(&mut config, cli.config.as_deref());
 
     if let Some(tty) = cli.tty {
+        info!("Overwritten the tty to '{}' with the --tty flag", tty);
         config.tty = tty;
     }
 


### PR DESCRIPTION
Allows to set the TTY in a unit definition instead of having to track TTY in two places (unit script and config.toml separately)