### PR TITLE
Remove dummy XDG_SESSION_ID

### DIFF
--- a/src/post_login/env_variables.rs
+++ b/src/post_login/env_variables.rs
@@ -39,7 +39,8 @@ pub fn set_xdg_env(uid: u32, homedir: &str, tty: u8) {
 
     env_set_and_announce("XDG_RUNTIME_DIR", &format!("/run/user/{}", uid));
     env_set_and_announce("XDG_SESSION_DIR", "user");
-    env_set_and_announce("XDG_SESSION_ID", "1");
+    // env_set_and_announce("XDG_SESSION_ID", "1");
+    // pam_systemd.so will set this for us
     env_set_and_announce("XDG_SEAT", "seat0");
     env_set_and_announce("XDG_VTNR", &tty.to_string());
 }


### PR DESCRIPTION
I liked this project the moment I saw it, and then replaced sddm with it. However, I found a issue preventing KDE Plasma on Wayland from starting. After several days of debugging, I made it :)

The `env_variables.rs` sets the environment variable `XDG_SESSION_ID` to an constant of `1`, which will cause some permission problems. Since the `pam_systemd.so` will automatically requests an `XDG_SESSION_ID` for us and then sets this variable to the correct value, would you mind removing this dummy `XDG_SESSION_ID` ?