### PR TITLE
Clear password input even on successful login

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -586,12 +586,13 @@ fn attempt_login<'a, TR, PC, SC, A, S>(
     status_message.set(InfoStatusMessage::Authenticating);
     send_ui_request(UIThreadRequest::Redraw);
 
+    // Clear the password field
+    password_clear();
+
     let user_info = match auth_fn(username, password) {
         Err(err) => {
             status_message.set(ErrorStatusMessage::AuthenticationError(err));
 
-            // Clear the password field
-            password_clear();
             send_ui_request(UIThreadRequest::Redraw);
 
             return;


### PR DESCRIPTION
This is a fix for #111. This does not change much. It just moves the password clear to always happen instead of only happening on an incorrect password.