### PR TITLE
Add `shell_login_flag` option in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "lemurs"
-version = "0.4.0"
+version = "0.3.1"
 dependencies = [
  "crossterm 0.22.1",
  "env_logger",

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -44,6 +44,13 @@ tty = 2
 # The PAM service that should be used to login
 pam_service = "lemurs"
 
+# The type flag that will be appended to the shell that calls the session
+# environment. This may depend on your shell. Options:
+# - 'none'. Disables calling a login shell
+# - 'short'. Produces the `-l` flag. Supported by most shells.
+# - 'long'. This produces the `--login` flag and is suited for bash and zsh.
+shell_login_flag = "short"
+
 # Focus behaviour of fields when Lemurs is initially started
 # 
 # Possible values:

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,8 @@ toml_config_struct! { Config, PartialConfig,
 
     pam_service => String,
 
+    shell_login_flag => ShellLoginFlag,
+
     focus_behaviour => FocusBehaviour,
 
     power_controls => PowerControlConfig [PartialPowerControlConfig],
@@ -265,6 +267,16 @@ pub enum FocusBehaviour {
     Username,
     #[serde(rename = "password")]
     Password,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum ShellLoginFlag {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "short")]
+    Short,
+    #[serde(rename = "long")]
+    Long,
 }
 
 impl Default for Config {

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -199,19 +199,18 @@ impl PostLoginEnvironment {
             }
             PostLoginEnvironment::Wayland { script_path } => {
                 info!("Starting Wayland session");
-                let child =
-                    match client
-                        .arg(script_path)
-                        .stdout(Stdio::piped())
-                        .stderr(Stdio::piped())
-                        .spawn()
-                    {
-                        Ok(child) => child,
-                        Err(err) => {
-                            error!("Failed to start Wayland Compositor. Reason '{err}'");
-                            return Err(EnvironmentStartError::WaylandStart);
-                        }
-                    };
+                let child = match client
+                    .arg(script_path)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .spawn()
+                {
+                    Ok(child) => child,
+                    Err(err) => {
+                        error!("Failed to start Wayland Compositor. Reason '{err}'");
+                        return Err(EnvironmentStartError::WaylandStart);
+                    }
+                };
 
                 Ok(SpawnedEnvironment::Wayland(child))
             }


### PR DESCRIPTION
This fixes #128 by adding an option `shell_login_flag` that allows users to set their own login flag. The default is `short` since most shells seems to allow the `-l` flag as an option.