### PR TITLE
#137 Allow function key input when focused on text box.

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -485,7 +485,7 @@ impl LoginForm {
                                 }
                                 InputMode::Username => self.widgets.username_guard().key_press(k),
                                 InputMode::Password => self.widgets.password_guard().key_press(k),
-                                InputMode::Normal => self.widgets.power_menu.key_press(k),
+                                _ => None,
                             };
 
                             // We don't wanna clear any existing error messages

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -472,6 +472,10 @@ impl LoginForm {
                             input_mode.set(InputMode::Normal);
                         }
 
+                        (KeyCode::F(_), _) => {
+                            self.widgets.power_menu.key_press(key.code);
+                        }
+
                         // For the different input modes the key should be passed to the corresponding
                         // widget.
                         (k, mode) => {


### PR DESCRIPTION
"Add additional key press checks to allow power menu functionality when focused on a text window."

Not sure if the additional 'Normal Mode' keypress should be removed. Is essentially redundant now.