### PR TITLE
Signal defined X server boot up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "libc 0.2.139",
  "log",
  "nix",
+ "once_cell",
  "pam",
  "pgs-files",
  "rand",
@@ -219,6 +220,12 @@ name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "pam"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ pam = "0.7.0"
 pgs-files = "0.0.7"
 users = "0.11.0"
 
+# Once Cell
+once_cell = "1.17.1"
+
 # Logging
 env_logger = { version = "0.9.0", default-features = false }
 log = "0.4.0"

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -44,6 +44,10 @@ tty = 2
 # The value of the `DISPLAY` environment variable for X11 sessions
 x11_display = ":1"
 
+# How many seconds to give the X server to start. To make it infinitely, put it
+# to 0.
+xserver_timeout_secs = 60
+
 # The PAM service that should be used to login
 pam_service = "lemurs"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,7 +152,9 @@ macro_rules! toml_config_struct {
 
 toml_config_struct! { Config, PartialConfig,
     tty => u8,
+
     x11_display => String,
+    xserver_timeout_secs => u16,
 
     pam_service => String,
 

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -179,8 +179,8 @@ impl PostLoginEnvironment {
         match self {
             PostLoginEnvironment::X { xinitrc_path } => {
                 info!("Starting X11 session");
-                let server =
-                    setup_x(process_env, user_info).map_err(EnvironmentStartError::XSetup)?;
+                let server = setup_x(process_env, user_info, config)
+                    .map_err(EnvironmentStartError::XSetup)?;
 
                 let client = match client
                     .arg(format!("{} {}", "/etc/lemurs/xsetup.sh", xinitrc_path))

--- a/src/post_login/x.rs
+++ b/src/post_login/x.rs
@@ -173,14 +173,14 @@ pub fn setup_x(
 
             if let Some(mut stdout) = child.stdout.take() {
                 let mut buf = String::new();
-                if let Ok(_) = stdout.read_to_string(&mut buf) {
+                if stdout.read_to_string(&mut buf).is_ok() {
                     error!("X server STDOUT: '''\n{buf}\n'''");
                 }
             }
 
             if let Some(mut stdout) = child.stdout.take() {
                 let mut buf = String::new();
-                if let Ok(_) = stdout.read_to_string(&mut buf) {
+                if stdout.read_to_string(&mut buf).is_ok() {
                     error!("X server STDERR: '''\n{buf}\n'''");
                 }
             }


### PR DESCRIPTION
As initiated by #139.

Instead of the Ly implementation that was currently being used, this PR uses the signals from Xorg to detect when it is ready to receive connections. There is currently a 30s timeout for the X server to start.

Things to add before completion:
- [x] Make timeout configurable
- [x] Detect when Xorg has crashed and Timeout earlier