### PR TITLE
Properly handle client exiting

### DIFF
--- a/extra/config.toml
+++ b/extra/config.toml
@@ -55,6 +55,9 @@ client_log_path = "/var/log/lemurs.client.log"
 # Where to log to for the XServer.
 xserver_log_path = "/var/log/lemurs.xorg.log"
 
+# Disable all logging. This is overwritten by the `--no-log` flag.
+no_log = false
+
 # The PAM service that should be used to login
 pam_service = "lemurs"
 

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -48,6 +48,13 @@ x11_display = ":1"
 # to 0.
 xserver_timeout_secs = 60
 
+# Where to log to for the client. The Client is the Desktop Environment or
+# Window Manager for Xorg, the Compositor for Wayland and the Shell for TTY.
+client_log_path = "/var/log/lemurs.client.log"
+
+# Where to log to for the XServer.
+xserver_log_path = "/var/log/lemurs.xorg.log"
+
 # The PAM service that should be used to login
 pam_service = "lemurs"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,8 @@ toml_config_struct! { Config, PartialConfig,
     client_log_path => String,
     xserver_log_path => String,
 
+    no_log => bool,
+
     pam_service => String,
 
     shell_login_flag => ShellLoginFlag,

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,9 @@ toml_config_struct! { Config, PartialConfig,
     x11_display => String,
     xserver_timeout_secs => u16,
 
+    client_log_path => String,
+    xserver_log_path => String,
+
     pam_service => String,
 
     shell_login_flag => ShellLoginFlag,

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     if !cli.no_log {
         setup_logger(cli.preview);
         info!("Lemurs logger is running");
+    } else {
+        config.no_log = true;
     }
 
     if !cli.preview {

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -172,13 +172,18 @@ impl PostLoginEnvironment {
             ShellLoginFlag::Long => Some("--login"),
         };
 
-        let client = lower_command_permissions_to_user(Command::new(SYSTEM_SHELL), user_info);
+        let mut client = lower_command_permissions_to_user(Command::new(SYSTEM_SHELL), user_info);
 
-        info!(
-            "Setup client to log `stdout` and `stderr` to '{log_path}'",
-            log_path = config.client_log_path
-        );
-        let mut client = output_command_to_log(client, Path::new(&config.client_log_path));
+        let mut client = if config.no_log {
+            client.stdout(Stdio::null()).stderr(Stdio::null());
+            client
+        } else {
+            info!(
+                "Setup client to log `stdout` and `stderr` to '{log_path}'",
+                log_path = config.client_log_path
+            );
+            output_command_to_log(client, Path::new(&config.client_log_path))
+        };
 
         if let Some(shell_login_flag) = shell_login_flag {
             client.arg(shell_login_flag);

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -139,9 +139,16 @@ impl SpawnedEnvironment {
                     }
                 };
 
+                info!("Killing X server");
                 match server.kill() {
                     Ok(_) => {}
                     Err(err) => error!("Failed to terminate X11. Reason: {err}"),
+                }
+
+                info!("Waiting for X server");
+                match server.wait() {
+                    Ok(_) => {}
+                    Err(err) => error!("Failed to wait for X11. Reason: {err}"),
                 }
             }
             Self::Wayland(mut client) | Self::Tty(mut client) => match client.wait() {

--- a/src/post_login/x.rs
+++ b/src/post_login/x.rs
@@ -135,12 +135,18 @@ pub fn setup_x(
         libc::signal(SIGUSR1, SIG_IGN);
     }
 
-    let child = Command::new(super::SYSTEM_SHELL);
-    info!(
-        "Setup XServer to log `stdout` and `stderr` to '{log_path}'",
-        log_path = config.xserver_log_path
-    );
-    let mut child = output_command_to_log(child, Path::new(&config.xserver_log_path));
+    let mut child = Command::new(super::SYSTEM_SHELL);
+
+    let mut child = if config.no_log {
+        child.stdout(Stdio::null()).stderr(Stdio::null());
+        child
+    } else {
+        info!(
+            "Setup XServer to log `stdout` and `stderr` to '{log_path}'",
+            log_path = config.xserver_log_path
+        );
+        output_command_to_log(child, Path::new(&config.xserver_log_path))
+    };
     let mut child = child
         .arg("-c")
         .arg(format!("/usr/bin/X {display_value} vt{doubledigit_vtnr}"))


### PR DESCRIPTION
This PR fixes #135, #34.

It moves the stdout & stderr logging of the client and X server from the main lemurs log `lemurs.log` to its own separate files (`lemurs.client.log` and `lemurs.xorg.log`). This way, it does not inhibit the client or X server from terminating. The paths to these logging files are configurable.