### PR TITLE
remove hardcoded .xinitrc from install.sh 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,10 +46,10 @@ $ROOT_CMD cp -f "extra/xsetup.sh" "/etc/lemurs/xsetup.sh"
 if [ $? -ne 0 ]; then exit 1; fi
 
 # Copy over default xinitrc
-if [ -f .xinitrc ]
+if [ -f $XINITRC ]
 then
     echo 'Copy over existing xinitrc'
-	$ROOT_CMD cp -f "~/.xinitrc" "/etc/lemurs/wms/xinitrc"
+	$ROOT_CMD cp -f "$XINITRC" "/etc/lemurs/wms/xinitrc"
 fi
 
 # Cache the current user

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,12 @@ $ROOT_CMD cp -f "extra/xsetup.sh" "/etc/lemurs/xsetup.sh"
 if [ $? -ne 0 ]; then exit 1; fi
 
 # Copy over default xinitrc
-if [ -f $XINITRC ]
+if [ -z "${XINITRC}" ]
+then
+    XINITRC="$HOME/.xinitrc"
+fi
+
+if [ -f "$XINITRC" ]
 then
     echo 'Copy over existing xinitrc'
 	$ROOT_CMD cp -f "$XINITRC" "/etc/lemurs/wms/xinitrc"


### PR DESCRIPTION
Changing the hardcoded xinitrc location to match the envirinmental variable per https://x.org/releases/X11R7.6/doc/man/man1/xinit.1.xhtml#heading5