### PR TITLE
Add timestamps to logs (fix #132)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
+ "humantime",
  "log",
 ]
 
@@ -101,6 +102,12 @@ dependencies = [
  "libc 0.2.139",
  "wasi",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "instant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ users = "0.11.0"
 once_cell = "1.17.1"
 
 # Logging
-env_logger = { version = "0.9.0", default-features = false }
+env_logger = { version = "0.9.0", default-features = false, features = ["humantime"] }
 log = "0.4.0"
 
 # Configuration File Parsing

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ fn setup_logger(log_path: &str) {
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)
         .target(env_logger::Target::Pipe(log_file))
+        .format_timestamp_secs()
         .init();
 }
 


### PR DESCRIPTION
Add timestamps to the logs via the `humantime` feature on `env_logger`.

This formats the logs as such:
```
[2023-05-11T16:23:47Z INFO  lemurs] Main lemurs logger is running
```