### PR TITLE
Add config option to change the visibility of the switcher (#70)

### DIFF
--- a/extra/config.toml
+++ b/extra/config.toml
@@ -137,6 +137,23 @@ hint_margin = 2
 # ---------
 #
 
+# Control the visiblity of the switcher
+# Options:
+# - "visible" - Always show the switcher [default]
+# - "hidden"  - Always hide the switcher
+# - [key]     - F1-F12 to be able to toggle the visiblity
+switcher_visibility = "visible"
+
+# The text in the top-left to display how to toggle the switcher. The text '%key%' will be
+# replaced with the switcher_visibility key.
+# This is not shown if switcher_visiblity is set to "visible" or "hidden".
+toggle_hint = "Switcher %key%"
+
+# The color and modifiers of the hint in the top-left corner
+toggle_hint_color = "dark gray"
+toggle_hint_modifiers = ""
+
+
 # Show an option for the TTY shell when logging in as one of the environments. 
 # NOTE: it is always shown when no viable options are found. 
 include_tty_shell = false

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -144,9 +144,9 @@ hint_margin = 2
 # - [key]     - F1-F12 to be able to toggle the visiblity
 switcher_visibility = "visible"
 
-# The text in the top-left to display how to toggle the switcher. The text '%key%' will be
-# replaced with the switcher_visibility key.
-# This is not shown if switcher_visiblity is set to "visible" or "hidden".
+# The text in the top-left to display how to toggle the switcher. The text
+# '%key%' will be replaced with the switcher_visibility key. This is not shown
+# if switcher_visiblity is set to "visible" or "hidden".
 toggle_hint = "Switcher %key%"
 
 # The color and modifiers of the hint in the top-left corner

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,6 +193,11 @@ toml_config_struct! { PowerControlConfig, PartialPowerControlConfig,
 }
 
 toml_config_struct! { SwitcherConfig, PartialSwitcherConfig,
+    switcher_visibility => SwitcherVisibility,
+    toggle_hint => String,
+    toggle_hint_color => String,
+    toggle_hint_modifiers => String,
+
     include_tty_shell => bool,
 
     remember => bool,
@@ -286,6 +291,29 @@ pub enum ShellLoginFlag {
     Short,
     #[serde(rename = "long")]
     Long,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SwitcherVisibility {
+    Visible,
+    Hidden,
+    Keybind(KeyCode),
+}
+
+/// Deserialise from a string of "visible", "hidden", or the keybind ("F1"-"F12")
+impl<'de> Deserialize<'de> for SwitcherVisibility {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+
+        Ok(match s {
+            "visible" => Self::Visible,
+            "hidden" => Self::Hidden,
+            k => Self::Keybind(get_key(k)),
+        })
+    }
 }
 
 impl Default for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -311,7 +311,16 @@ impl<'de> Deserialize<'de> for SwitcherVisibility {
         Ok(match s {
             "visible" => Self::Visible,
             "hidden" => Self::Hidden,
-            k => Self::Keybind(get_key(k)),
+            key => {
+                let Some(keycode) = get_function_key(key) else {
+                    return Err(D::Error::custom(
+                        "Invalid key provided to toggle switcher visibility. Only F1-F12 are allowed"
+                    ));
+                    
+                };
+
+                Self::Keybind(keycode)
+            },
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,10 +114,7 @@ pub fn get_key(key: &str) -> KeyCode {
         return fn_key;
     }
 
-    match key.trim() {
-        // TODO: Add others
-        _ => KeyCode::F(255),
-    }
+    KeyCode::F(255)
 }
 
 macro_rules! partial_struct_field {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::process;
 
 use crossterm::event::KeyCode;
 use log::error;
-use serde::{Deserialize, de::Error};
+use serde::{de::Error, Deserialize};
 
 use tui::style::{Color, Modifier};
 
@@ -330,7 +330,7 @@ impl<'de> Deserialize<'de> for SwitcherVisibility {
                 };
 
                 Self::Keybind(keycode)
-            },
+            }
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -326,7 +326,7 @@ impl<'de> Deserialize<'de> for SwitcherVisibility {
                     return Err(D::Error::custom(
                         "Invalid key provided to toggle switcher visibility. Only F1-F12 are allowed"
                     ));
-                    
+
                 };
 
                 Self::Keybind(keycode)

--- a/src/ui/chunks.rs
+++ b/src/ui/chunks.rs
@@ -6,8 +6,7 @@ use tui::{
 use Constraint::{Length, Min};
 
 pub struct Chunks {
-    pub power_menu: Rect,
-    pub switcher_toggle_menu: Rect,
+    pub key_menu: Rect,
     pub switcher: Rect,
     pub username_field: Rect,
     pub password_field: Rect,
@@ -38,8 +37,7 @@ impl Chunks {
             .split(frame.size());
 
         Self {
-            power_menu: chunks[0],
-            switcher_toggle_menu: chunks[1],
+            key_menu: chunks[0],
             switcher: chunks[3],
             username_field: chunks[5],
             password_field: chunks[7],

--- a/src/ui/chunks.rs
+++ b/src/ui/chunks.rs
@@ -7,6 +7,7 @@ use Constraint::{Length, Min};
 
 pub struct Chunks {
     pub power_menu: Rect,
+    pub switcher_toggle_menu: Rect,
     pub switcher: Rect,
     pub username_field: Rect,
     pub password_field: Rect,
@@ -38,6 +39,7 @@ impl Chunks {
 
         Self {
             power_menu: chunks[0],
+            switcher_toggle_menu: chunks[1],
             switcher: chunks[3],
             username_field: chunks[5],
             password_field: chunks[7],

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -405,43 +405,6 @@ impl<T> SwitcherWidget<T> {
     }
 }
 
-#[derive(Clone)]
-pub struct SwitcherToggleMenuWidget {
-    config: SwitcherConfig,
-}
-
-impl SwitcherToggleMenuWidget {
-    pub fn new(config: SwitcherConfig) -> Self {
-        Self { config }
-    }
-    fn toggle_style(&self) -> Style {
-        let mut style = Style::default().fg(get_color(&self.config.toggle_hint_color));
-
-        for modifier in get_modifiers(&self.config.toggle_hint_modifiers) {
-            style = style.add_modifier(modifier);
-        }
-
-        style
-    }
-
-    pub fn render(&self, frame: &mut Frame<impl tui::backend::Backend>, area: Rect) {
-        let mut items = Vec::new();
-
-        if let SwitcherVisibility::Keybind(KeyCode::F(n)) = self.config.switcher_visibility {
-            items.push(Span::styled(
-                self.config.toggle_hint.replace("%key%", &format!("F{n}")),
-                self.toggle_style(),
-            ));
-        }
-
-        let mut text = Text::raw("");
-        text.lines.push(Spans(items));
-        let widget = Paragraph::new(text);
-
-        frame.render_widget(widget, area);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ui/switcher.rs
+++ b/src/ui/switcher.rs
@@ -275,6 +275,10 @@ impl<T> SwitcherWidget<T> {
         items.push(Span::raw(right_padding));
     }
 
+    pub fn hidden(&self) -> bool {
+        self.hidden
+    }
+
     pub fn render(
         &self,
         frame: &mut Frame<impl tui::backend::Backend>,


### PR DESCRIPTION
This addresses #70.

Adds a config option, `switcher_visibility`, which allows the user to switch between `"visible"`, `"hidden"`, `"F1"`, ..., `"F12"`, for always visible, always hidden, and a key to toggle the visibility.  

When `switcher_visibility` is set to a key, a hint appears in the top-left corner, under the shutdown/reboot hints, by default, the format for the hint is `"Switcher %key%"`.

When `switcher_visibiltiy` is set to `"hidden"`, cycling through input fields skips over the switcher, to prevent it from being selected/modified.