### PR TITLE
initial background widget code(#157)

### DIFF
--- a/extra/config.toml
+++ b/extra/config.toml
@@ -81,6 +81,19 @@ shell_login_flag = "short"
 # - password: Initially focus on the password field
 focus_behaviour = "default"
 
+# General settings for background style
+[background]
+
+# Control whether to render background widget or not
+show_background = false
+
+[background.style]
+# Allow to set the default background color for the login shell
+color = "black"
+# Settings for the background block's borders
+show_border = true
+border_color = "white"
+
 [power_controls]
 # Allow for the shutdown option to be used
 allow_shutdown = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,10 +175,23 @@ toml_config_struct! { Config, PartialConfig,
 
     focus_behaviour => FocusBehaviour,
 
+    background => BackgroundConfig [PartialBackgroundConfig],
+
     power_controls => PowerControlConfig [PartialPowerControlConfig],
     environment_switcher => SwitcherConfig [PartialSwitcherConfig],
     username_field => UsernameFieldConfig [PartialUsernameFieldConfig],
     password_field => PasswordFieldConfig [PartialPasswordFieldConfig],
+}
+
+toml_config_struct! { BackgroundStyleConfig, PartialBackgroundStyleConfig,
+    color => String,
+    show_border => bool,
+    border_color => String,
+}
+
+toml_config_struct! { BackgroundConfig, PartialBackgroundConfig,
+    show_background => bool,
+    style => BackgroundStyleConfig [PartialBackgroundStyleConfig],
 }
 
 toml_config_struct! { PowerControlConfig, PartialPowerControlConfig,

--- a/src/ui/background.rs
+++ b/src/ui/background.rs
@@ -1,0 +1,44 @@
+use ratatui::{
+    style::Style,
+    widgets::{Block, Borders},
+    Frame,
+};
+
+use crate::config::{get_color, BackgroundConfig};
+
+#[derive(Clone)]
+pub struct BackgroundWidget {
+    config: BackgroundConfig,
+}
+
+impl BackgroundWidget {
+    pub fn new(config: BackgroundConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn render(&self, frame: &mut Frame<impl ratatui::backend::Backend>) {
+        if !self.config.show_background {
+            return;
+        }
+        let block = Block::default().style(self.background_style());
+
+        let bounding_box = frame.size();
+
+        let block = if self.config.style.show_border {
+            block
+                .borders(Borders::ALL)
+                .border_style(self.border_style())
+        } else {
+            block
+        };
+
+        frame.render_widget(block, bounding_box);
+    }
+
+    fn background_style(&self) -> Style {
+        Style::default().bg(get_color(&self.config.style.color))
+    }
+    fn border_style(&self) -> Style {
+        Style::default().fg(get_color(&self.config.style.border_color))
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,7 @@ use crossterm::terminal::{
 use ratatui::backend::CrosstermBackend;
 use ratatui::{backend::Backend, Frame, Terminal};
 
+mod background;
 mod chunks;
 mod input_field;
 mod key_menu;
@@ -31,6 +32,8 @@ use input_field::{InputFieldDisplayType, InputFieldWidget};
 use key_menu::KeyMenuWidget;
 use status_message::{ErrorStatusMessage, InfoStatusMessage};
 use switcher::{SwitcherItem, SwitcherWidget};
+
+use self::background::BackgroundWidget;
 
 #[derive(Clone)]
 struct LoginFormInputMode(Arc<Mutex<InputMode>>);
@@ -162,6 +165,7 @@ enum UIThreadRequest {
 
 #[derive(Clone)]
 struct Widgets {
+    background: BackgroundWidget,
     key_menu: KeyMenuWidget,
     environment: Arc<Mutex<SwitcherWidget<PostLoginEnvironment>>>,
     username: Arc<Mutex<InputFieldWidget>>,
@@ -280,6 +284,7 @@ impl LoginForm {
         LoginForm {
             preview,
             widgets: Widgets {
+                background: BackgroundWidget::new(config.background.clone()),
                 key_menu: KeyMenuWidget::new(
                     config.power_controls.clone(),
                     config.environment_switcher.clone(),
@@ -341,7 +346,7 @@ impl LoginForm {
             FocusBehaviour::Password => InputMode::Password,
         });
         let status_message = LoginFormStatusMessage::new();
-
+        let background = self.widgets.background.clone();
         let key_menu = self.widgets.key_menu.clone();
         let environment = self.widgets.environment.clone();
         let username = self.widgets.username.clone();
@@ -352,6 +357,7 @@ impl LoginForm {
             login_form_render(
                 f,
                 layout,
+                background.clone(),
                 key_menu.clone(),
                 environment.clone(),
                 username.clone(),
@@ -555,6 +561,7 @@ impl LoginForm {
                         login_form_render(
                             f,
                             layout,
+                            background.clone(),
                             key_menu.clone(),
                             environment.clone(),
                             username.clone(),
@@ -595,6 +602,7 @@ impl LoginForm {
 fn login_form_render<B: Backend>(
     frame: &mut Frame<B>,
     chunks: Chunks,
+    background: BackgroundWidget,
     key_menu: KeyMenuWidget,
     environment: Arc<Mutex<SwitcherWidget<PostLoginEnvironment>>>,
     username: Arc<Mutex<InputFieldWidget>>,
@@ -602,6 +610,7 @@ fn login_form_render<B: Backend>(
     input_mode: InputMode,
     status_message: Option<StatusMessage>,
 ) {
+    background.render(frame);
     key_menu.render(frame, chunks.key_menu);
     environment
         .lock()


### PR DESCRIPTION
This is a simplistic way to address #157, with as little additional code as possible. If this is good enough, I'd be happy to add more options to the background widget, but overall, I think it's better to keep it as simple as possible for now until theming (#7) and variable interpolation(#71) are addressed. Seems to work fine in the tty on my arch vm as well.