### PR TITLE
Remove dependency on pgs_files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "libc 0.2.147",
+ "libc",
  "mio",
  "parking_lot",
  "signal-hook",
@@ -74,7 +74,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
- "libc 0.2.147",
+ "libc",
  "wasi",
 ]
 
@@ -90,13 +90,12 @@ version = "0.3.1"
 dependencies = [
  "crossterm",
  "env_logger",
- "libc 0.2.147",
+ "libc",
  "log",
  "mio",
  "nix",
  "once_cell",
  "pam",
- "pgs-files",
  "rand",
  "ratatui",
  "serde",
@@ -104,12 +103,6 @@ dependencies = [
  "unicode-width",
  "users 0.11.0",
 ]
-
-[[package]]
-name = "libc"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
@@ -148,7 +141,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
- "libc 0.2.147",
+ "libc",
  "log",
  "wasi",
  "windows-sys",
@@ -163,7 +156,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
- "libc 0.2.147",
+ "libc",
  "memoffset",
 ]
 
@@ -179,7 +172,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa2bdc959c201c047004a1420a92aaa1dd1a6b64d5ef333aa3a4ac764fb93097"
 dependencies = [
- "libc 0.2.147",
+ "libc",
  "pam-sys",
  "users 0.8.1",
 ]
@@ -190,7 +183,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4858311a097f01a0006ef7d0cd50bca81ec430c949d7bf95cbefd202282434"
 dependencies = [
- "libc 0.2.147",
+ "libc",
 ]
 
 [[package]]
@@ -210,19 +203,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
- "libc 0.2.147",
+ "libc",
  "redox_syscall",
  "smallvec",
  "windows-targets",
-]
-
-[[package]]
-name = "pgs-files"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7b7d377867a5a16859f9521ea3b884438f6e3eb096ffd18014243125faf715"
-dependencies = [
- "libc 0.1.12",
 ]
 
 [[package]]
@@ -255,7 +239,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.147",
+ "libc",
  "rand_chacha",
  "rand_core",
 ]
@@ -333,7 +317,7 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
- "libc 0.2.147",
+ "libc",
  "signal-hook-registry",
 ]
 
@@ -343,7 +327,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
- "libc 0.2.147",
+ "libc",
  "mio",
  "signal-hook",
 ]
@@ -354,7 +338,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
- "libc 0.2.147",
+ "libc",
 ]
 
 [[package]]
@@ -407,7 +391,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fed7d0912567d35f88010c23dbaf865e9da8b5227295e8dc0f2fdd109155ab7"
 dependencies = [
- "libc 0.2.147",
+ "libc",
 ]
 
 [[package]]
@@ -416,7 +400,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
 dependencies = [
- "libc 0.2.147",
+ "libc",
  "log",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ libc = "0.2"
 
 # Authentication and Fetching User Data
 pam = "0.7.0"
-pgs-files = "0.0.7"
 users = "0.11.0"
 
 # Once Cell

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -13,11 +13,11 @@ pub struct AuthUserInfo<'a> {
     #[allow(dead_code)]
     authenticator: Authenticator<'a, PasswordConv>,
 
-    pub name: String,
-    pub uid: u32,
-    pub gid: u32,
-    pub gecos: String,
-    pub dir: String,
+    pub username: String,
+    pub uid: libc::uid_t,
+    pub primary_gid: libc::gid_t,
+    pub all_gids: Vec<libc::gid_t>,
+    pub home_dir: String,
     pub shell: String,
 }
 
@@ -28,22 +28,12 @@ pub fn try_auth<'a>(
 ) -> Result<AuthUserInfo<'a>, AuthenticationError> {
     info!("Login attempt for '{username}'");
 
-    open_session(username, password, pam_service)
-        .map(|(authenticator, entry)| AuthUserInfo {
-            authenticator,
-            name: entry.name,
-            uid: entry.uid,
-            gid: entry.gid,
-            gecos: entry.gecos,
-            dir: entry.dir,
-            shell: entry.shell,
-        })
-        .map_err(|err| {
-            info!(
-                "Authentication failed for '{}'. Reason: {}",
-                username,
-                err.to_string()
-            );
-            err
-        })
+    open_session(username, password, pam_service).map_err(|err| {
+        info!(
+            "Authentication failed for '{}'. Reason: {}",
+            username,
+            err.to_string()
+        );
+        err
+    })
 }

--- a/src/auth/pam.rs
+++ b/src/auth/pam.rs
@@ -35,9 +35,6 @@ pub fn open_session<'a>(
     password: &str,
     pam_service: &str,
 ) -> Result<AuthUserInfo<'a>, AuthenticationError> {
-    let username = username.to_string();
-    let password = password.to_string();
-
     info!("Started opening session");
 
     let mut authenticator = Authenticator::with_password(pam_service)
@@ -48,7 +45,7 @@ pub fn open_session<'a>(
     // Authenticate the user
     authenticator
         .get_handler()
-        .set_credentials(&username, &password);
+        .set_credentials(username, password);
 
     info!("Got handler");
 
@@ -59,7 +56,7 @@ pub fn open_session<'a>(
 
     info!("Validated account");
 
-    let user = users::get_user_by_name(&username).ok_or(AuthenticationError::UsernameNotFound)?;
+    let user = users::get_user_by_name(username).ok_or(AuthenticationError::UsernameNotFound)?;
 
     let uid = user.uid();
     let primary_gid = user.primary_group_id();

--- a/src/env_container.rs
+++ b/src/env_container.rs
@@ -86,7 +86,7 @@ impl Drop for EnvironmentContainer {
             }
         }
 
-        info!("Reverting to working directory before session");
+        info!("Reverting to environment before session");
         if env::set_current_dir(&self.snapshot_pwd).is_err() {
             error!(
                 "Failed to change the working directory back to {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn start_session(
 
     let tty = config.tty;
     let uid = auth_session.uid;
-    let homedir = &auth_session.dir;
+    let homedir = &auth_session.home_dir;
     let shell = &auth_session.shell;
 
     set_seat_vars(&mut process_env, tty);

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -84,7 +84,7 @@ fn lower_command_permissions_to_user(
         .all_gids
         .iter()
         .cloned()
-        .map(|gid| Gid::from_raw(gid))
+        .map(Gid::from_raw)
         .collect::<Vec<Gid>>();
 
     unsafe {

--- a/src/post_login/x.rs
+++ b/src/post_login/x.rs
@@ -83,8 +83,11 @@ pub fn setup_x(
     let vtnr_value = env::var("XDG_VTNR").map_err(|_| XSetupError::VTNREnvVar)?;
 
     // Setup xauth
-    let xauth_dir =
-        PathBuf::from(env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| user_info.dir.to_string()));
+    let xauth_dir = if let Ok(config_home) = env::var("XDG_CONFIG_HOME") {
+        PathBuf::from(config_home)
+    } else {
+        PathBuf::from(user_info.home_dir.clone())
+    };
     let xauth_path = xauth_dir.join(".Xauthority");
 
     info!(
@@ -104,7 +107,7 @@ pub fn setup_x(
             mcookie()
         ))
         .uid(user_info.uid)
-        .gid(user_info.gid)
+        .gid(user_info.primary_gid)
         .stdout(Stdio::null()) // TODO: Maybe this should be logged or something?
         .stderr(Stdio::null()) // TODO: Maybe this should be logged or something?
         .status()


### PR DESCRIPTION
This PR removes the dependency on `pgs_files` as a dependency and uses the `users` crate instead. It also pulls the groups at the same times as the rest of the user information.