### PR TITLE
Configurize hardcoded paths

### DIFF
--- a/extra/config.toml
+++ b/extra/config.toml
@@ -48,6 +48,10 @@ main_log_path = "/var/log/lemurs.log"
 # Window Manager for Xorg, the Compositor for Wayland and the Shell for TTY.
 client_log_path = "/var/log/lemurs.client.log"
 
+# At which point to point the cache. If you want to disable the cache globally
+# you can use `/dev/null`.
+cache_path = "/var/cache/lemurs";
+
 # Disable all logging. This is overwritten by the `--no-log` flag.
 do_log = true
 

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -324,3 +324,11 @@ xserver_path = "/usr/bin/X"
 
 # Where to find the X11 xauth binary
 xauth_path = "/usr/bin/xauth"
+
+# Path to the directory where the startup scripts for the X11 sessions are found
+scripts_path = "/etc/lemurs/wms"
+
+[wayland]
+# Path to the directory where the startup scripts for the Wayland sessions are
+# found
+scripts_path = "/etc/lemurs/wayland"

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -41,22 +41,12 @@
 # The tty which contains lemurs. This has to be mirrored in the lemurs.service
 tty = 2
 
-# The value of the `DISPLAY` environment variable for X11 sessions
-x11_display = ":1"
-
-# How many seconds to give the X server to start. To make it infinitely, put it
-# to 0.
-xserver_timeout_secs = 60
-
 # Where to log the main lemurs control flow.
 main_log_path = "/var/log/lemurs.log"
 
 # Where to log to for the client. The Client is the Desktop Environment or
 # Window Manager for Xorg, the Compositor for Wayland and the Shell for TTY.
 client_log_path = "/var/log/lemurs.client.log"
-
-# Where to log to for the XServer.
-xserver_log_path = "/var/log/lemurs.xorg.log"
 
 # Disable all logging. This is overwritten by the `--no-log` flag.
 do_log = true
@@ -317,3 +307,20 @@ border_color_focused = "orange"
 use_max_width = true
 # The contraint of the password field's width
 max_width = 48
+
+[x11]
+# Where to log to for the XServer.
+xserver_log_path = "/var/log/lemurs.xorg.log"
+
+# The value of the `DISPLAY` environment variable for X11 sessions
+x11_display = ":1"
+
+# How many seconds to give the X server to start. To make it infinitely, put it
+# to 0.
+xserver_timeout_secs = 60
+
+# Where to find the X11 server binary
+xserver_path = "/usr/bin/X"
+
+# Where to find the X11 xauth binary
+xauth_path = "/usr/bin/xauth"

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -54,6 +54,10 @@ do_log = true
 # The PAM service that should be used to login
 pam_service = "lemurs"
 
+# Path to system shell that gets used to execute linux commands. In almost all
+# cases, this should refer to a bash shell.
+system_shell = "/usr/sh"
+
 # The type flag that will be appended to the shell that calls the session
 # environment. This may depend on your shell. Options:
 # - 'none'. Disables calling a login shell

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -50,7 +50,7 @@ client_log_path = "/var/log/lemurs.client.log"
 
 # At which point to point the cache. If you want to disable the cache globally
 # you can use `/dev/null`.
-cache_path = "/var/cache/lemurs";
+cache_path = "/var/cache/lemurs"
 
 # Disable all logging. This is overwritten by the `--no-log` flag.
 do_log = true

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -332,6 +332,10 @@ xauth_path = "/usr/bin/xauth"
 # Path to the directory where the startup scripts for the X11 sessions are found
 scripts_path = "/etc/lemurs/wms"
 
+# Path to the xsetup script that is needed for the environment setup of the
+# window manager.
+xsetup_path = "/etc/lemurs/xsetup.sh"
+
 [wayland]
 # Path to the directory where the startup scripts for the Wayland sessions are
 # found

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,129 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712407774,
+        "narHash": "sha256-6rHekl0F8HU6vGGJAy7RrOrE6gHFlkq7aD9Z53Q18l8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ce4a55c9197da0b8d7eb162e618911c319bc9a4a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1712369449,
+        "narHash": "sha256-tbWug3uXPlSm1j0xD80Y3xbP+otT6gLnQo1e/vQat48=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "41b3b080cc3e4b3a48e933b87fc15a05f1870779",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "A flake to build a Rust project to WASM";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    utils.url = "github:numtide/flake-utils";
+
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, utils, rust-overlay }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        packageName = "lemurs";
+        
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+  
+        rustToolchain = pkgs.rust-bin.stable.latest.default;
+  
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+      in {
+        packages.default = rustPlatform.buildRustPackage {
+          name = packageName;
+          src = ./.;
+
+          postPatch = ''
+            substituteInPlace extra/config.toml \
+              --replace-fail "/usr/sh" "${pkgs.bash}/bin/bash"
+
+            substituteInPlace extra/config.toml \
+              --replace-fail "/usr/bin/X" "${pkgs.xorg.xorgserver}/bin/X"
+
+            substituteInPlace extra/config.toml \
+              --replace-fail "/usr/bin/xauth" "${pkgs.xorg.xauth}/bin/xauth"
+          '';
+
+          buildInputs = [
+            pkgs.linux-pam
+          ];
+          
+          cargoLock.lockFile = ./Cargo.lock;
+      };
+    }
+  );
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,7 @@ toml_config_struct! { Config, PartialConfig, RoughConfig,
     do_log => bool,
 
     pam_service => String,
+    system_shell => String,
 
     shell_login_flag => ShellLoginFlag,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -361,7 +361,6 @@ toml_config_struct! { PasswordFieldConfig, PartialPasswordFieldConfig, RoughPass
     style => InputFieldStyle [PartialInputFieldStyle, RoughInputFieldStyle],
 }
 
-
 toml_config_struct! { X11Config, PartialX11Config, RoughX11Config,
     x11_display => String,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -213,6 +213,7 @@ toml_config_struct! { Config, PartialConfig, RoughConfig,
 
     main_log_path => String,
     client_log_path => String,
+    cache_path => String,
 
     do_log => bool,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,17 +230,7 @@ toml_config_struct! { Config, PartialConfig, RoughConfig,
     password_field => PasswordFieldConfig [PartialPasswordFieldConfig, RoughPasswordFieldConfig],
 
     x11 => X11Config [PartialX11Config, RoughX11Config],
-}
-
-toml_config_struct! { X11Config, PartialX11Config, RoughX11Config,
-    x11_display => String,
-
-    xserver_timeout_secs => u16,
-
-    xserver_log_path => String,
-
-    xserver_path => String,
-    xauth_path => String,
+    wayland => WaylandConfig [PartialWaylandConfig, RoughWaylandConfig],
 }
 
 toml_config_struct! { BackgroundStyleConfig, PartialBackgroundStyleConfig, RoughBackgroundStyleConfig,
@@ -368,6 +358,24 @@ toml_config_struct! { UsernameFieldConfig, PartialUsernameFieldConfig, RoughUser
 toml_config_struct! { PasswordFieldConfig, PartialPasswordFieldConfig, RoughPasswordFieldConfig,
     content_replacement_character => char,
     style => InputFieldStyle [PartialInputFieldStyle, RoughInputFieldStyle],
+}
+
+
+toml_config_struct! { X11Config, PartialX11Config, RoughX11Config,
+    x11_display => String,
+
+    xserver_timeout_secs => u16,
+
+    xserver_log_path => String,
+
+    xserver_path => String,
+    xauth_path => String,
+
+    scripts_path => String,
+}
+
+toml_config_struct! { WaylandConfig, PartialWaylandConfig, RoughWaylandConfig,
+    scripts_path => String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,12 +211,8 @@ pub struct Variables(toml::value::Table);
 toml_config_struct! { Config, PartialConfig, RoughConfig,
     tty => u8,
 
-    x11_display => String,
-    xserver_timeout_secs => u16,
-
     main_log_path => String,
     client_log_path => String,
-    xserver_log_path => String,
 
     do_log => bool,
 
@@ -232,6 +228,19 @@ toml_config_struct! { Config, PartialConfig, RoughConfig,
     environment_switcher => SwitcherConfig [PartialSwitcherConfig, RoughSwitcherConfig],
     username_field => UsernameFieldConfig [PartialUsernameFieldConfig, RoughUsernameFieldConfig],
     password_field => PasswordFieldConfig [PartialPasswordFieldConfig, RoughPasswordFieldConfig],
+
+    x11 => X11Config [PartialX11Config, RoughX11Config],
+}
+
+toml_config_struct! { X11Config, PartialX11Config, RoughX11Config,
+    x11_display => String,
+
+    xserver_timeout_secs => u16,
+
+    xserver_log_path => String,
+
+    xserver_path => String,
+    xauth_path => String,
 }
 
 toml_config_struct! { BackgroundStyleConfig, PartialBackgroundStyleConfig, RoughBackgroundStyleConfig,

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,6 +372,7 @@ toml_config_struct! { X11Config, PartialX11Config, RoughX11Config,
     xauth_path => String,
 
     scripts_path => String,
+    xsetup_path => String,
 }
 
 toml_config_struct! { WaylandConfig, PartialWaylandConfig, RoughWaylandConfig,

--- a/src/info_caching.rs
+++ b/src/info_caching.rs
@@ -1,7 +1,8 @@
 use log::{info, warn};
 use std::fs::{read_to_string, write};
 
-pub const CACHE_PATH: &str = "/var/cache/lemurs";
+use crate::config::Config;
+
 const USERNAME_LENGTH_LIMIT: usize = 32;
 
 // Saved in the /var/cache/lemurs file as
@@ -48,13 +49,12 @@ impl CachedInfo {
     }
 }
 
-pub fn get_cached_information() -> CachedInfo {
-    info!(
-        "Attempting to get a cached information from '{}'",
-        CACHE_PATH
-    );
+pub fn get_cached_information(config: &Config) -> CachedInfo {
+    let cache_path = &config.cache_path;
 
-    match read_to_string(CACHE_PATH) {
+    info!("Attempting to get a cached information from '{cache_path}'",);
+
+    match read_to_string(cache_path) {
         Ok(cached) => {
             // Remove any line feeds
             let cached = cached.trim().to_string();
@@ -102,8 +102,10 @@ pub fn get_cached_information() -> CachedInfo {
     }
 }
 
-pub fn set_cache(environment: Option<&str>, username: Option<&str>) {
-    info!("Attempting to set cache");
+pub fn set_cache(environment: Option<&str>, username: Option<&str>, config: &Config) {
+    let cache_path = &config.cache_path;
+
+    info!("Attempting to set cache: {cache_path}");
 
     let username = if let Some(username) = username {
         // Username length check
@@ -129,9 +131,9 @@ pub fn set_cache(environment: Option<&str>, username: Option<&str>) {
         username.unwrap_or_default()
     );
 
-    match write(CACHE_PATH, cache_file_content) {
+    match write(cache_path, cache_file_content) {
         Err(err) => {
-            warn!("Failed to set username to cache file. Reason: '{}'", err);
+            warn!("Failed to set username to cache file. Reason: '{err}'");
         }
         _ => {
             info!("Successfully set username in cache file");

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,7 @@ fn start_session(
     }
 
     if matches!(post_login_env, PostLoginEnvironment::X { .. }) {
-        set_display(&config.x11_display, &mut process_env);
+        set_display(&config.x11.x11_display, &mut process_env);
     }
     set_session_params(&mut process_env, post_login_env);
     remove_xdg(&mut process_env);

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if let Some(cmd) = cli.command {
         match cmd {
             Commands::Envs => {
-                let envs = post_login::get_envs(config.environment_switcher.include_tty_shell);
+                let envs = post_login::get_envs(&config);
 
                 for (env_name, _) in envs.into_iter() {
                     println!("{env_name}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,14 +151,14 @@ fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
             Commands::Cache => {
-                let cached_info = info_caching::get_cached_information();
+                let cached_info = info_caching::get_cached_information(&config);
 
                 let environment = cached_info.environment().unwrap_or("No cached value");
                 let username = cached_info.username().unwrap_or("No cached value");
 
                 println!(
                     "Information currently cached within '{}'\n",
-                    info_caching::CACHE_PATH
+                    config.cache_path
                 );
 
                 println!("environment: '{environment}'");

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -23,9 +23,6 @@ mod x;
 
 const SYSTEM_SHELL: &str = "/bin/sh";
 
-const INITRCS_FOLDER_PATH: &str = "/etc/lemurs/wms";
-const WAYLAND_FOLDER_PATH: &str = "/etc/lemurs/wayland";
-
 #[derive(Debug, Clone)]
 pub enum PostLoginEnvironment {
     X { xinitrc_path: String },
@@ -238,11 +235,11 @@ impl PostLoginEnvironment {
     }
 }
 
-pub fn get_envs(with_tty_shell: bool) -> Vec<(String, PostLoginEnvironment)> {
+pub fn get_envs(config: &Config) -> Vec<(String, PostLoginEnvironment)> {
     // NOTE: Maybe we can do something smart with `with_capacity` here.
     let mut envs = Vec::new();
 
-    match fs::read_dir(INITRCS_FOLDER_PATH) {
+    match fs::read_dir(&config.x11.scripts_path) {
         Ok(paths) => {
             for path in paths {
                 if let Ok(path) = path {
@@ -282,11 +279,11 @@ pub fn get_envs(with_tty_shell: bool) -> Vec<(String, PostLoginEnvironment)> {
             }
         }
         Err(_) => {
-            warn!("Failed to read from the X folder '{}'", INITRCS_FOLDER_PATH);
+            warn!("Failed to read from the X folder '{}'", config.x11.scripts_path);
         }
     }
 
-    match fs::read_dir(WAYLAND_FOLDER_PATH) {
+    match fs::read_dir(&config.wayland.scripts_path) {
         Ok(paths) => {
             for path in paths {
                 if let Ok(path) = path {
@@ -329,12 +326,12 @@ pub fn get_envs(with_tty_shell: bool) -> Vec<(String, PostLoginEnvironment)> {
         Err(_) => {
             warn!(
                 "Failed to read from the wayland folder '{}'",
-                WAYLAND_FOLDER_PATH
+                config.wayland.scripts_path
             );
         }
     }
 
-    if envs.is_empty() || with_tty_shell {
+    if envs.is_empty() || config.environment_switcher.include_tty_shell {
         envs.push(("TTYSHELL".to_string(), PostLoginEnvironment::Shell));
     }
 

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -165,7 +165,8 @@ impl PostLoginEnvironment {
             ShellLoginFlag::Long => Some("--login"),
         };
 
-        let mut client = lower_command_permissions_to_user(Command::new(&config.system_shell), user_info);
+        let mut client =
+            lower_command_permissions_to_user(Command::new(&config.system_shell), user_info);
 
         let log_path = config.do_log.then_some(Path::new(&config.client_log_path));
 
@@ -277,7 +278,10 @@ pub fn get_envs(config: &Config) -> Vec<(String, PostLoginEnvironment)> {
             }
         }
         Err(_) => {
-            warn!("Failed to read from the X folder '{}'", config.x11.scripts_path);
+            warn!(
+                "Failed to read from the X folder '{}'",
+                config.x11.scripts_path
+            );
         }
     }
 

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -21,8 +21,6 @@ pub(crate) mod env_variables;
 mod wait_with_log;
 mod x;
 
-const SYSTEM_SHELL: &str = "/bin/sh";
-
 #[derive(Debug, Clone)]
 pub enum PostLoginEnvironment {
     X { xinitrc_path: String },
@@ -167,7 +165,7 @@ impl PostLoginEnvironment {
             ShellLoginFlag::Long => Some("--login"),
         };
 
-        let mut client = lower_command_permissions_to_user(Command::new(SYSTEM_SHELL), user_info);
+        let mut client = lower_command_permissions_to_user(Command::new(&config.system_shell), user_info);
 
         let log_path = config.do_log.then_some(Path::new(&config.client_log_path));
 

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -183,7 +183,7 @@ impl PostLoginEnvironment {
                 let server = setup_x(process_env, user_info, config)
                     .map_err(EnvironmentStartError::XSetup)?;
 
-                client.arg(format!("{} {}", "/etc/lemurs/xsetup.sh", xinitrc_path));
+                client.arg(format!("{} {}", &config.x11.xsetup_path, xinitrc_path));
 
                 let client = match LemursChild::spawn(client, log_path) {
                     Ok(child) => child,

--- a/src/post_login/x.rs
+++ b/src/post_login/x.rs
@@ -102,7 +102,8 @@ pub fn setup_x(
     Command::new(super::SYSTEM_SHELL)
         .arg("-c")
         .arg(format!(
-            "/usr/bin/xauth add {} . {}",
+            "{} add {} . {}",
+            &config.x11.xauth_path,
             display_value,
             mcookie()
         ))
@@ -140,11 +141,11 @@ pub fn setup_x(
 
     let mut child = Command::new(super::SYSTEM_SHELL);
 
-    let log_path = config.do_log.then_some(Path::new(&config.xserver_log_path));
+    let log_path = config.do_log.then_some(Path::new(&config.x11.xserver_log_path));
 
     child
         .arg("-c")
-        .arg(format!("/usr/bin/X {display_value} vt{doubledigit_vtnr}"));
+        .arg(format!("{} {display_value} vt{doubledigit_vtnr}", &config.x11.xserver_path));
 
     let mut child = LemursChild::spawn(child, log_path).map_err(|err| {
         error!("Failed to start X server. Reason: {}", err);
@@ -160,10 +161,10 @@ pub fn setup_x(
     // Wait for XServer to boot-up
     let start_time = time::SystemTime::now();
     loop {
-        if config.xserver_timeout_secs == 0
+        if config.x11.xserver_timeout_secs == 0
             || start_time
                 .elapsed()
-                .map_or(false, |t| t.as_secs() > config.xserver_timeout_secs.into())
+                .map_or(false, |t| t.as_secs() > config.x11.xserver_timeout_secs.into())
         {
             break;
         }

--- a/src/post_login/x.rs
+++ b/src/post_login/x.rs
@@ -141,11 +141,14 @@ pub fn setup_x(
 
     let mut child = Command::new(&config.system_shell);
 
-    let log_path = config.do_log.then_some(Path::new(&config.x11.xserver_log_path));
+    let log_path = config
+        .do_log
+        .then_some(Path::new(&config.x11.xserver_log_path));
 
-    child
-        .arg("-c")
-        .arg(format!("{} {display_value} vt{doubledigit_vtnr}", &config.x11.xserver_path));
+    child.arg("-c").arg(format!(
+        "{} {display_value} vt{doubledigit_vtnr}",
+        &config.x11.xserver_path
+    ));
 
     let mut child = LemursChild::spawn(child, log_path).map_err(|err| {
         error!("Failed to start X server. Reason: {}", err);
@@ -162,9 +165,9 @@ pub fn setup_x(
     let start_time = time::SystemTime::now();
     loop {
         if config.x11.xserver_timeout_secs == 0
-            || start_time
-                .elapsed()
-                .map_or(false, |t| t.as_secs() > config.x11.xserver_timeout_secs.into())
+            || start_time.elapsed().map_or(false, |t| {
+                t.as_secs() > config.x11.xserver_timeout_secs.into()
+            })
         {
             break;
         }

--- a/src/post_login/x.rs
+++ b/src/post_login/x.rs
@@ -99,7 +99,7 @@ pub fn setup_x(
     // a `root` permission `.Xauthority` file there.
     let _ = remove_file(xauth_path.clone());
 
-    Command::new(super::SYSTEM_SHELL)
+    Command::new(&config.system_shell)
         .arg("-c")
         .arg(format!(
             "{} add {} . {}",
@@ -139,7 +139,7 @@ pub fn setup_x(
         libc::signal(SIGUSR1, SIG_IGN);
     }
 
-    let mut child = Command::new(super::SYSTEM_SHELL);
+    let mut child = Command::new(&config.system_shell);
 
     let log_path = config.do_log.then_some(Path::new(&config.x11.xserver_log_path));
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -352,7 +352,7 @@ impl LoginForm {
         let username = self.widgets.username.clone();
         let password = self.widgets.password.clone();
 
-        match terminal.draw(|f| {
+        let draw_action = terminal.draw(|f| {
             let layout = Chunks::new(f);
             login_form_render(
                 f,
@@ -365,12 +365,11 @@ impl LoginForm {
                 input_mode.get(),
                 status_message.get(),
             );
-        }) {
-            Ok(_) => {}
-            Err(err) => {
-                error!("Failed to draw. Reason: {}", err);
-                std::process::exit(1);
-            }
+        });
+
+        if let Err(err) = draw_action {
+            error!("Failed to draw. Reason: {}", err);
+            std::process::exit(1);
         }
 
         let event_input_mode = input_mode.clone();
@@ -556,7 +555,7 @@ impl LoginForm {
         while let Ok(request) = req_recv_channel.recv() {
             match request {
                 UIThreadRequest::Redraw => {
-                    match terminal.draw(|f| {
+                    let draw_action = terminal.draw(|f| {
                         let layout = Chunks::new(f);
                         login_form_render(
                             f,
@@ -569,9 +568,10 @@ impl LoginForm {
                             input_mode.get(),
                             status_message.get(),
                         );
-                    }) {
-                        Ok(_) => {}
-                        Err(err) => warn!("Failed to draw to screen. Reason: {err}"),
+                    });
+
+                    if let Err(err) = draw_action {
+                        warn!("Failed to draw to screen. Reason: {err}");
                     }
                 }
                 UIThreadRequest::DisableTui => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -290,7 +290,7 @@ impl LoginForm {
                     config.environment_switcher.clone(),
                 ),
                 environment: Arc::new(Mutex::new(SwitcherWidget::new(
-                    crate::post_login::get_envs(config.environment_switcher.include_tty_shell)
+                    crate::post_login::get_envs(&config)
                         .into_iter()
                         .map(|(title, content)| SwitcherItem::new(title, content))
                         .collect(),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -257,14 +257,14 @@ impl LoginForm {
             .then_some(self.widgets.get_username());
 
         info!("Setting cached information");
-        set_cache(selected_env.as_deref(), username.as_deref());
+        set_cache(selected_env.as_deref(), username.as_deref(), &self.config);
     }
 
     fn load_cache(&self) {
         let env_remember = self.config.environment_switcher.remember;
         let username_remember = self.config.username_field.remember;
 
-        let cached = get_cached_information();
+        let cached = get_cached_information(&self.config);
 
         if username_remember {
             if let Some(username) = cached.username() {


### PR DESCRIPTION
This PR pushes several of the hard-coded paths in the code to the configuration file. This is part of the solution to address #177.

There is still work to be done on the `xsetup.sh` script and the environment initialization.