### PR TITLE
Add support for desktop entry files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deentry"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "866170d551fbf7e49a7fe5160092933f210fe1853cf0cbf5d81957b941bdb690"
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +98,7 @@ name = "lemurs"
 version = "0.3.2"
 dependencies = [
  "crossterm",
+ "deentry",
  "env_logger",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ unicode-width = "0.1"
 
 mio = { version = "0.8.8", features = [ "os-poll", "os-ext" ] }
 
+deentry = "0.0.1"
+
 # Interacting with the kernel interfaces
 rand = "0.8.4"
 nix = "0.23.1"

--- a/extra/config.toml
+++ b/extra/config.toml
@@ -340,7 +340,13 @@ scripts_path = "/etc/lemurs/wms"
 # window manager.
 xsetup_path = "/etc/lemurs/xsetup.sh"
 
+# The directory to use for desktop entries X11 sessions.
+xsessions_path = "/usr/share/xsessions"
+
 [wayland]
 # Path to the directory where the startup scripts for the Wayland sessions are
 # found
 scripts_path = "/etc/lemurs/wayland"
+
+# The directory to use for desktop entries wayland sessions.
+wayland_sessions_path = "/usr/share/wayland-sessions"

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,12 @@
           ];
           
           cargoLock.lockFile = ./Cargo.lock;
-      };
-    }
+        };
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            linux-pam
+          ];
+        };
+      }
   );
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -374,10 +374,12 @@ toml_config_struct! { X11Config, PartialX11Config, RoughX11Config,
 
     scripts_path => String,
     xsetup_path => String,
+    xsessions_path => String,
 }
 
 toml_config_struct! { WaylandConfig, PartialWaylandConfig, RoughWaylandConfig,
     scripts_path => String,
+    wayland_sessions_path => String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -254,11 +254,11 @@ fn parse_desktop_entry(path: &Path, _: &Config) -> Result<(String, String), Stri
         .iter()
         .find(|g| g.name() == "Desktop Entry")
     else {
-        return Err(format!("file does not contain 'Desktop Entry' group"));
+        return Err("file does not contain 'Desktop Entry' group".to_string());
     };
 
     let Some(exec) = desktop_entry.get("Exec") else {
-        return Err(format!("'Exec' key cannot be found"));
+        return Err("'Exec' key cannot be found".to_string());
     };
 
     let exec = match exec.value().as_string() {

--- a/src/post_login/mod.rs
+++ b/src/post_login/mod.rs
@@ -315,8 +315,7 @@ pub fn get_envs(config: &Config) -> Vec<(String, PostLoginEnvironment)> {
         }
     }
 
-    match fs::read_dir(&config.wayland.wayland_sessions_path
-    ) {
+    match fs::read_dir(&config.wayland.wayland_sessions_path) {
         Ok(paths) => {
             for path in paths {
                 let Ok(path) = path else {


### PR DESCRIPTION
This resolves #102 and utilizes [coastalwhite/deentry](https://github.com/coastalwhite/deentry). To resolve the license issues with existing desktop entry parsers.