### PR TITLE
Update installation instructions with the Lemurs Arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,18 @@ Installation follows three steps.
 
 ### Arch Linux
 
-Lemurs can be installed from the [AUR](https://aur.archlinux.org/packages/lemurs). This will
-build the package on your local machine.
+Lemurs can be installed from the [extra](https://archlinux.org/packages/?sort=&q=lemurs&maintainer=&flagged=) repository.
 
 ```bash
-paru -S lemurs # paru can be replaced by any other AUR helper
+sudo pacman -S lemurs
 
 # Not needed if you don't have a window manager yet
 sudo systemctl disable display-manager.service
 
 sudo systemctl enable lemurs.service
 ```
+
+Alternatively, [lemur-git](https://aur.archlinux.org/packages/lemurs-git) is available in the AUR.
 
 ### Compiling from source
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo systemctl disable display-manager.service
 sudo systemctl enable lemurs.service
 ```
 
-Alternatively, [lemur-git](https://aur.archlinux.org/packages/lemurs-git) is available in the AUR.
+Alternatively, [lemurs-git](https://aur.archlinux.org/packages/lemurs-git) is available in the AUR.
 
 ### Compiling from source
 


### PR DESCRIPTION
Hello,

Lemurs is now available in the Arch Linux [[extra] repository](https://archlinux.org/packages/extra/x86_64/lemurs/).
This PR aims to update the installation instructions in the README accordingly.

I also left [a comment](https://aur.archlinux.org/packages/lemurs-git#comment-969799) on the lemurs-git AUR package with a few things that should be corrected.

Thanks for your great work on Lemurs! :slightly_smiling_face: 

I remain available if needed.