### PR TITLE
docs: add i3 window manager example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ Remember to make this script runnable. This is done with the `sudo chmod 755
 
 Upon rebooting your new `sway` should show up within Lemurs.
 
+### Example 3: i3wm
+
+For the [i3wm](https://i3wm.org/) window manager, you might
+add the script `/etc/lemurs/wms/i3wm`.
+
+```bash
+#! /bin/sh
+exec i3
+```
+
+Remember to make this script runnable. This is done with the `sudo chmod 755
+/etc/lemurs/wms/i3wm` command.
+
+Upon rebooting your new `i3wm` should show up within Lemurs.
+
 ## Configuration
 
 Configuration is done through a [TOML] file. By default, Lemurs searches for a


### PR DESCRIPTION
This PR adds i3 window manager as Xorg example to be more convenient for i3wm users.