### PR TITLE
append logs if they exist, otherwise create

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ pub fn initialize_panic_handler() {
 }
 
 fn setup_logger(log_path: &str) {
-    let log_file = Box::new(File::create(log_path).unwrap_or_else(|_| {
+    let log_file = Box::new(File::options().append(true).create(true).open(log_path).unwrap_or_else(|_| {
         eprintln!("Failed to open log file: '{log_path}'");
         std::process::exit(1);
     }));

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,10 +129,16 @@ pub fn initialize_panic_handler() {
 }
 
 fn setup_logger(log_path: &str) {
-    let log_file = Box::new(File::options().append(true).create(true).open(log_path).unwrap_or_else(|_| {
-        eprintln!("Failed to open log file: '{log_path}'");
-        std::process::exit(1);
-    }));
+    let log_file = Box::new(
+        File::options()
+            .append(true)
+            .create(true)
+            .open(log_path)
+            .unwrap_or_else(|_| {
+                eprintln!("Failed to open log file: '{log_path}'");
+                std::process::exit(1);
+            }),
+    );
 
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)


### PR DESCRIPTION
Small change, but I hope it helps people improve `lemurs` and debug more easily. For some reason I've never been able to log back in after a hibernate, but I could never debug it because the logs kept on getting overwritten on restart.

This change opens the logs in append mode, but keeps the create if non-existant as well.

https://doc.rust-lang.org/std/fs/struct.OpenOptions.html