### PR TITLE
feat: update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,8 +65,11 @@ echo 'Copy over PAM service'
 inst 'extra/lemurs.pam' '/etc/pam.d/lemurs'
 
 # Cache the current user
-echo 'Caching the current user'
-echo "xinitrc\n$USER" | "$ROOT_CMD" tee /var/cache/lemurs > /dev/null || exit 1
+cache='/var/cache/lemurs'
+if ! [ -s "$cache" ]; then
+    echo 'Caching the current user'
+    echo "xinitrc\n$USER" | "$ROOT_CMD" tee "$cache" > /dev/null || exit 1
+fi
 
 # Disable previous Display Manager
 echo 'Disabling the current display-manager. This might throw an error if no display manager is set up.'


### PR DESCRIPTION
- copy files using install, not cp. its -C (compare) flag ensures unchanged files won't be copied, meaning targets' mtimes don't get unnecessarily changed; additionally install gives a simple option to enforce target file permissions
- do not allow running as root
- all in all this should make install.sh more idempotent