### PR TITLE
fix: evaluation warning from `meta.mainProgram` not being set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,23 +8,31 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { self, nixpkgs, utils, rust-overlay }:
-    utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      utils,
+      rust-overlay,
+    }:
+    utils.lib.eachDefaultSystem (
+      system:
       let
         packageName = "lemurs";
-        
+
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
-  
+
         rustToolchain = pkgs.rust-bin.stable.latest.default;
-  
+
         rustPlatform = pkgs.makeRustPlatform {
           cargo = rustToolchain;
           rustc = rustToolchain;
         };
-      in {
+      in
+      {
         packages.default = rustPlatform.buildRustPackage {
           name = packageName;
           src = ./.;
@@ -43,7 +51,9 @@
           buildInputs = [
             pkgs.linux-pam
           ];
-          
+
+          meta.mainProgram = "lemurs";
+
           cargoLock.lockFile = ./Cargo.lock;
         };
         devShells.default = pkgs.mkShell {
@@ -54,5 +64,5 @@
           ];
         };
       }
-  );
+    );
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crossterm::event::KeyCode;
 use log::error;
+use ratatui::style::{Color, Modifier};
 use serde::{de::Error, Deserialize};
 use std::fmt::Display;
 use std::fs::File;
@@ -7,26 +8,6 @@ use std::io::Read;
 use std::path::Path;
 use std::process;
 use toml::Value;
-
-use ratatui::style::{Color, Modifier};
-
-#[derive(Debug)]
-pub struct VarError {
-    variable: String,
-    pos: usize,
-}
-
-impl std::error::Error for VarError {}
-
-impl Display for VarError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Variable {} not found at position {}",
-            self.variable, self.pos
-        )
-    }
-}
 
 pub fn get_color(color: &str) -> Color {
     if let Some(color) = str_to_color(color) {

--- a/src/post_login/wait_with_log.rs
+++ b/src/post_login/wait_with_log.rs
@@ -146,17 +146,11 @@ impl LimitedOutputChild {
         let file = file_options.open(log_path)?;
 
         let Some(stdout) = process.stdout.take() else {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Failed to grab stdout",
-            ));
+            return Err(io::Error::other("Failed to grab stdout"));
         };
 
         let Some(stderr) = process.stderr.take() else {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Failed to grab stderr",
-            ));
+            return Err(io::Error::other("Failed to grab stderr"));
         };
 
         let mut stdout_receiver = Receiver::from(stdout);
@@ -222,7 +216,7 @@ impl LimitedOutputChild {
                         event.is_read_closed(),
                     )?,
                     _ => {
-                        return Err(io::Error::new(io::ErrorKind::Other, "Invalid event"));
+                        return Err(io::Error::other("Invalid event"));
                     }
                 }
             }

--- a/src/ui/input_field.rs
+++ b/src/ui/input_field.rs
@@ -244,7 +244,7 @@ impl InputFieldWidget {
         }
     }
 
-    fn get_block(&self, is_focused: bool) -> Block {
+    fn get_block(&self, is_focused: bool) -> Block<'_> {
         let (title_style, border_style) = if is_focused {
             (
                 Style::default().fg(get_color(&self.style.title_color_focused)),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,7 +43,7 @@ impl LoginFormInputMode {
         Self(Arc::new(Mutex::new(mode)))
     }
 
-    fn get_guard(&self) -> MutexGuard<InputMode> {
+    fn get_guard(&self) -> MutexGuard<'_, InputMode> {
         let Self(mutex) = self;
 
         match mutex.lock() {
@@ -78,7 +78,7 @@ impl LoginFormStatusMessage {
         Self(Arc::new(Mutex::new(None)))
     }
 
-    fn get_guard(&self) -> MutexGuard<Option<StatusMessage>> {
+    fn get_guard(&self) -> MutexGuard<'_, Option<StatusMessage>> {
         let Self(mutex) = self;
 
         match mutex.lock() {
@@ -173,7 +173,7 @@ struct Widgets {
 }
 
 impl Widgets {
-    fn environment_guard(&self) -> MutexGuard<SwitcherWidget<PostLoginEnvironment>> {
+    fn environment_guard(&self) -> MutexGuard<'_, SwitcherWidget<PostLoginEnvironment>> {
         match self.environment.lock() {
             Ok(guard) => guard,
             Err(err) => {
@@ -182,7 +182,7 @@ impl Widgets {
             }
         }
     }
-    fn username_guard(&self) -> MutexGuard<InputFieldWidget> {
+    fn username_guard(&self) -> MutexGuard<'_, InputFieldWidget> {
         match self.username.lock() {
             Ok(guard) => guard,
             Err(err) => {
@@ -191,7 +191,7 @@ impl Widgets {
             }
         }
     }
-    fn password_guard(&self) -> MutexGuard<InputFieldWidget> {
+    fn password_guard(&self) -> MutexGuard<'_, InputFieldWidget> {
         match self.password.lock() {
             Ok(guard) => guard,
             Err(err) => {


### PR DESCRIPTION
Installing `lemurs` using the flake in this repository emits the following warning when rebuilding my system.
```
evaluation warning: getExe: Package lemurs does not have the meta.mainProgram
attribute. We'll assume that the main program has the same name for now,
but this behavior is deprecated, because it leads to surprising errors
when the assumption does not hold. If the package has a main program,
please set `meta.mainProgram` in its definition to make this warning
go away. Otherwise, if the package does not have a main program, or if
you don't control its definition, use getExe' to specify the name to the
program, such as lib.getExe' foo "bar".
```
> formatted for line-wrap

This is a straight forward fix that sets `meta.mainProgram = "lemurs"`. Any changed nix files are formatted using `nixfmt`.