### PR TITLE
Handle interrupts on thread polling

### DIFF
--- a/src/post_login/wait_with_log.rs
+++ b/src/post_login/wait_with_log.rs
@@ -8,7 +8,7 @@ use std::thread::JoinHandle;
 
 use std::io::Read;
 
-use log::info;
+use log::{info, error};
 use mio::unix::pipe::Receiver;
 use mio::{Events, Interest, Poll, Token, Waker};
 
@@ -168,7 +168,14 @@ impl LimitedOutputChild {
         let mut file_handle = LimitSizeWriter::new(file, LOG_WRITER_SIZE_LIMIT);
 
         let join_handle = std::thread::spawn(move || loop {
-            poll.poll(&mut events, None)?;
+            if let Err(e) = poll.poll(&mut events, None) {
+                if e.kind() == io::ErrorKind::Interrupted {
+                    // EINTR is expected during suspend/resume, just retry
+                    continue;
+                }
+                error!("poll() error: {}", e);
+                continue;
+            }
 
             fn forward_receiver_to_file(
                 receiver: &mut Receiver,

--- a/src/post_login/wait_with_log.rs
+++ b/src/post_login/wait_with_log.rs
@@ -174,7 +174,7 @@ impl LimitedOutputChild {
                     continue;
                 }
                 error!("poll() error: {}", e);
-                continue;
+                return Err(e);
             }
 
             fn forward_receiver_to_file(

--- a/src/post_login/wait_with_log.rs
+++ b/src/post_login/wait_with_log.rs
@@ -8,7 +8,7 @@ use std::thread::JoinHandle;
 
 use std::io::Read;
 
-use log::{info, error};
+use log::{error, info};
 use mio::unix::pipe::Receiver;
 use mio::{Events, Interest, Poll, Token, Waker};
 


### PR DESCRIPTION
This PR catches polling interruptions of child threads that happen during suspend/resume. The goal is to fix #257 

Retries when an interrupt signal but still propogates the error up the same as before for all other errors.

It does add a log entry also, when this suspend/resume issue happened before it took me a while to figure out what was going on because it didn't seem to log. Figured if something happens with this poll it would be nice to know in the future.