### PR TITLE
fix: retry log-forwarding poll on EINTR to survive suspend/hibernate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
 					able-to-login = pkgs.callPackage ./tests/able-to-login.nix { inherit self; };
 					graphical-sway-login = pkgs.callPackage ./tests/graphical-sway-login.nix { inherit self; };
 					relogin = pkgs.callPackage ./tests/relogin.nix { inherit self; };
+					suspend-resume = pkgs.callPackage ./tests/suspend-resume.nix { inherit self; };
 				terminate-session = pkgs.callPackage ./tests/terminate-session.nix { inherit self; };
 				};
       }

--- a/src/post_login/wait_with_log.rs
+++ b/src/post_login/wait_with_log.rs
@@ -15,6 +15,19 @@ use mio::{Events, Interest, Poll, Token, Waker};
 /// 64MB
 const LOG_WRITER_SIZE_LIMIT: usize = 67_108_864;
 
+/// Whether an error returned by [`Poll::poll`] should be retried rather than
+/// propagated.
+///
+/// `mio` surfaces an interrupted syscall (`EINTR`) as
+/// [`io::ErrorKind::Interrupted`] instead of retrying it internally. This most
+/// notably happens when the kernel process freezer interrupts the poll during a
+/// system suspend/hibernate cycle. Propagating it would make the client `wait`
+/// fail spuriously and tear down an otherwise-healthy session on resume, so such
+/// an error is retried; all other errors are propagated.
+fn should_retry_poll(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::Interrupted
+}
+
 struct LimitSizeWriter<W: io::Write> {
     writer: BufWriter<W>,
     current_byte_count: usize,
@@ -168,7 +181,16 @@ impl LimitedOutputChild {
         let mut file_handle = LimitSizeWriter::new(file, LOG_WRITER_SIZE_LIMIT);
 
         let join_handle = std::thread::spawn(move || loop {
-            poll.poll(&mut events, None)?;
+            // `poll` may be interrupted by a signal (`EINTR`), most notably by
+            // the kernel process freezer during a system suspend/hibernate
+            // cycle. Retry in that case instead of tearing down the session; see
+            // `should_retry_poll`.
+            if let Err(err) = poll.poll(&mut events, None) {
+                if should_retry_poll(&err) {
+                    continue;
+                }
+                return Err(err);
+            }
 
             fn forward_receiver_to_file(
                 receiver: &mut Receiver,
@@ -271,5 +293,31 @@ impl LimitedOutputChild {
 
     pub fn id(&self) -> u32 {
         self.process.id()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_retry_poll;
+    use std::io;
+
+    #[test]
+    fn retries_poll_on_interrupt() {
+        // An interrupted syscall (`EINTR`), e.g. from the kernel process freezer
+        // during suspend/hibernate, must be retried rather than propagated.
+        let interrupted = io::Error::from_raw_os_error(libc::EINTR);
+        assert_eq!(interrupted.kind(), io::ErrorKind::Interrupted);
+        assert!(should_retry_poll(&interrupted));
+    }
+
+    #[test]
+    fn propagates_other_poll_errors() {
+        for err in [
+            io::Error::from(io::ErrorKind::BrokenPipe),
+            io::Error::from(io::ErrorKind::PermissionDenied),
+            io::Error::from_raw_os_error(libc::EBADF),
+        ] {
+            assert!(!should_retry_poll(&err), "unexpectedly retried {err:?}");
+        }
     }
 }

--- a/src/post_login/wait_with_log.rs
+++ b/src/post_login/wait_with_log.rs
@@ -28,6 +28,19 @@ fn should_retry_poll(err: &io::Error) -> bool {
     err.kind() == io::ErrorKind::Interrupted
 }
 
+/// Runs `poll_once` (a single [`Poll::poll`] call), automatically retrying when
+/// it fails with a retryable interrupt (see [`should_retry_poll`]) and
+/// propagating any other error. Returns once a poll completes, so the caller can
+/// process the readiness events.
+fn poll_retrying_on_interrupt(mut poll_once: impl FnMut() -> io::Result<()>) -> io::Result<()> {
+    loop {
+        match poll_once() {
+            Err(err) if should_retry_poll(&err) => continue,
+            other => return other,
+        }
+    }
+}
+
 struct LimitSizeWriter<W: io::Write> {
     writer: BufWriter<W>,
     current_byte_count: usize,
@@ -184,13 +197,8 @@ impl LimitedOutputChild {
             // `poll` may be interrupted by a signal (`EINTR`), most notably by
             // the kernel process freezer during a system suspend/hibernate
             // cycle. Retry in that case instead of tearing down the session; see
-            // `should_retry_poll`.
-            if let Err(err) = poll.poll(&mut events, None) {
-                if should_retry_poll(&err) {
-                    continue;
-                }
-                return Err(err);
-            }
+            // `poll_retrying_on_interrupt`.
+            poll_retrying_on_interrupt(|| poll.poll(&mut events, None))?;
 
             fn forward_receiver_to_file(
                 receiver: &mut Receiver,
@@ -298,7 +306,7 @@ impl LimitedOutputChild {
 
 #[cfg(test)]
 mod tests {
-    use super::should_retry_poll;
+    use super::{poll_retrying_on_interrupt, should_retry_poll};
     use std::io;
 
     #[test]
@@ -319,5 +327,46 @@ mod tests {
         ] {
             assert!(!should_retry_poll(&err), "unexpectedly retried {err:?}");
         }
+    }
+
+    #[test]
+    fn poll_loop_proceeds_immediately_on_ok() {
+        let mut calls = 0;
+        let outcome = poll_retrying_on_interrupt(|| {
+            calls += 1;
+            Ok(())
+        });
+        assert!(outcome.is_ok());
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn poll_loop_retries_on_interrupt_then_proceeds() {
+        // Scripted poll results, consumed front-to-back via `pop`: two interrupts
+        // then a success. The loop should swallow both interrupts and return once
+        // the poll succeeds.
+        let mut remaining = vec![
+            Ok(()),
+            Err(io::Error::from_raw_os_error(libc::EINTR)),
+            Err(io::Error::from_raw_os_error(libc::EINTR)),
+        ];
+        let mut calls = 0;
+        let outcome = poll_retrying_on_interrupt(|| {
+            calls += 1;
+            remaining.pop().unwrap()
+        });
+        assert!(outcome.is_ok());
+        assert_eq!(calls, 3, "expected the two interrupts to be retried");
+    }
+
+    #[test]
+    fn poll_loop_propagates_non_interrupt_error_without_retrying() {
+        let mut calls = 0;
+        let outcome = poll_retrying_on_interrupt(|| {
+            calls += 1;
+            Err(io::Error::from(io::ErrorKind::BrokenPipe))
+        });
+        assert_eq!(outcome.unwrap_err().kind(), io::ErrorKind::BrokenPipe);
+        assert_eq!(calls, 1, "a non-interrupt error must not be retried");
     }
 }

--- a/tests/suspend-resume.nix
+++ b/tests/suspend-resume.nix
@@ -1,0 +1,110 @@
+{ self, pkgs }:
+
+pkgs.testers.nixosTest {
+  name = "suspend-resume";
+  nodes.machine =
+    { config, pkgs, ... }:
+    let
+      # Alice logs into a Wayland session that stays up until the test asks it to
+      # exit (by creating /tmp/please-exit). The clean exit is what makes lemurs
+      # run `stop_logging()` and join the log-forwarding thread -- which is where
+      # an interrupted poll surfaces as a spurious "Failed to wait for client".
+      aliceSession = pkgs.writeShellScript "alice-session" ''
+        touch /tmp/alice-session-started
+        while [ ! -e /tmp/please-exit ]; do
+          sleep 0.5
+        done
+        ${pkgs.sway}/bin/swaymsg exit
+      '';
+    in
+    {
+      services.displayManager.enable = true;
+      services.displayManager.lemurs = {
+        enable = true;
+        package = self.packages.${pkgs.system}.default;
+      };
+
+      virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+      services.seatd.enable = true;
+      programs.sway.enable = true;
+
+      users.users.alice = {
+        isNormalUser = true;
+        initialPassword = "test123";
+        extraGroups = [ "seat" "video" "input" ];
+      };
+
+      systemd.tmpfiles.rules =
+        let
+          swayConfig = pkgs.writeText "alice-sway-config" ''
+            exec ${pkgs.foot}/bin/foot -- ${aliceSession}
+          '';
+        in
+        [
+          "d /home/alice/.config 0755 alice users -"
+          "d /home/alice/.config/sway 0755 alice users -"
+          "L+ /home/alice/.config/sway/config - alice users - ${swayConfig}"
+        ];
+
+      system.stateVersion = "25.11";
+    };
+
+  # Regression test for the suspend/resume session teardown.
+  #
+  # The log-forwarding thread spawned per session blocks in `mio::Poll::poll`
+  # (epoll_wait). During a real suspend/hibernate the kernel process freezer
+  # interrupts that syscall with EINTR; mio 0.8 surfaces it as
+  # ErrorKind::Interrupted rather than retrying. Without the fix the thread
+  # returns that error and dies; `stop_logging()` -- which lemurs only runs once
+  # the client has exited -- then joins the dead thread and propagates the error
+  # out of the client `wait()`, logging "Failed to wait for client" and tearing
+  # the session down on the next resume/logout.
+  #
+  # We reproduce the interrupt deterministically with the cgroup v2 freezer (the
+  # same mechanism suspend uses): freezing then thawing the session's cgroup
+  # delivers EINTR to the poll. We then end the session cleanly so `stop_logging`
+  # runs. With the fix the poll is retried, the thread stays healthy, and the
+  # session tears down cleanly with no error in the log.
+  testScript = ''
+    machine.start()
+    machine.wait_for_file("/var/log/lemurs.log", 60)
+    machine.sleep(3)
+    machine.screenshot("01_before_login")
+
+    # --- Log in and wait for the session to come up ---
+    machine.send_key('down')
+    machine.send_chars('alice\n', 0.2)
+    machine.send_chars('test123\n', 0.2)
+    machine.wait_for_file("/tmp/alice-session-started", 60)
+    # Let the compositor settle so the log thread is parked in its blocking poll.
+    machine.sleep(5)
+    machine.screenshot("02_session_running")
+
+    # The log thread runs in the session-leader child, which elogind placed in
+    # the user's session scope alongside sway. Freezing that cgroup is what the
+    # suspend freezer does to the whole system.
+    sway_pid = machine.succeed("pgrep -x sway | head -n1").strip()
+    cgroup = machine.succeed(
+        "cut -d: -f3 /proc/%s/cgroup | head -n1" % sway_pid
+    ).strip()
+    freeze = "/sys/fs/cgroup%s/cgroup.freeze" % cgroup
+    machine.succeed("test -e " + freeze)
+
+    # --- Suspend surrogate: freeze then thaw, delivering EINTR to the poll ---
+    machine.succeed("echo 1 > " + freeze)
+    machine.sleep(2)
+    machine.succeed("echo 0 > " + freeze)
+    machine.sleep(3)
+    machine.screenshot("03_after_resume")
+
+    # --- End the session cleanly so lemurs runs stop_logging()/joins the thread ---
+    machine.succeed("touch /tmp/please-exit")
+    # Wait for lemurs to reap the client and return to the login screen.
+    machine.sleep(8)
+    machine.screenshot("04_after_session_exit")
+
+    # The interrupted poll must not surface as a client wait failure. This line
+    # appears with the bug and is absent with the fix.
+    machine.fail("grep -q 'Failed to wait for client' /var/log/lemurs.log")
+  '';
+}


### PR DESCRIPTION
## What

The log-forwarding thread spawned by `LimitedOutputChild::spawn` blocks in
`mio::Poll::poll(&mut events, None)?` with no timeout. `mio` surfaces an
interrupted syscall as `ErrorKind::Interrupted` rather than retrying, so when the
kernel process freezer interrupts the underlying `epoll_wait` during a system
suspend/hibernate cycle, the thread returns `Err`. That error propagates through
`stop_logging()` and out of `SpawnedEnvironment::wait`, which lemurs interprets as
the client having exited — so it tears down an otherwise-healthy session and
returns the user to the login screen on resume.

This affects the `do_log = true` path; `std::process::Child::wait` already retries
`EINTR` internally, so the no-log path is not expected to be affected (not tested).

## Change

Retry the poll on `ErrorKind::Interrupted`; propagate all other errors unchanged.

## Testing

Built from `main` on Artix (OpenRC), lemurs on tty2 supervising a niri Wayland
session, Intel i915. Before the change, hibernate resume reliably dropped to the
login screen with `Failed to wait for client. Reason: Interrupted system call
(os error 4)`. After the change, I ran six hibernate/resume cycles: the session
survived intact every time and the error no longer appears in `lemurs.log`.

Fixes #260. May also address #156.
