### PR TITLE
fix: don't tear down the session's pipes on EINTR

### DIFF
--- a/src/post_login/wait_with_log.rs
+++ b/src/post_login/wait_with_log.rs
@@ -168,7 +168,22 @@ impl LimitedOutputChild {
         let mut file_handle = LimitSizeWriter::new(file, LOG_WRITER_SIZE_LIMIT);
 
         let join_handle = std::thread::spawn(move || loop {
-            poll.poll(&mut events, None)?;
+            // `poll(2)` is never restarted after a signal, even with SA_RESTART
+            // (see signal(7)), and mio surfaces the resulting EINTR to the
+            // caller rather than retrying it.
+            //
+            // Returning here is not harmless: unwinding this closure drops
+            // `stdout_receiver`/`stderr_receiver`, which closes the read ends of
+            // the session process' stdout/stderr pipes. The session process then
+            // takes SIGPIPE on its next write and dies. Signals are routinely
+            // delivered around suspend/resume, which makes this reachable during
+            // ordinary use, and the resulting error is only surfaced much later
+            // by `stop_logging()`, long after the session is gone.
+            match poll.poll(&mut events, None) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                Err(err) => return Err(err),
+            }
 
             fn forward_receiver_to_file(
                 receiver: &mut Receiver,
@@ -190,6 +205,9 @@ impl LimitedOutputChild {
                         Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
                             break;
                         }
+                        // Same reasoning as the `poll()` call above: a signal
+                        // must not tear down the pipes.
+                        Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
                         Err(err) => return Err(err),
                         Ok(n) => {
                             file_handle.write_all(&buf[..n])?;


### PR DESCRIPTION
`poll(2)` is never restarted after a signal, even with SA_RESTART -- signal(7) lists select/pselect/poll/ppoll as always failing with EINTR -- and mio surfaces that error to the caller rather than retrying. The log-forwarding thread propagated it with `?` and returned.

Returning is not harmless. Unwinding the closure drops `stdout_receiver` and `stderr_receiver`, which closes the read ends of the session process' stdout/stderr pipes. The session process then takes SIGPIPE on its next write; if it does not handle SIGPIPE it dies immediately, taking the graphical session down with it. lemurs surfaces the original EINTR only later, when `stop_logging()` joins the thread, as

    Failed to wait for client. Reason: Interrupted system call (os error 4)

which is logged after the session is already gone and masks the child's real exit status.

Signals are routinely delivered around suspend/resume, making this reachable in ordinary use: observed as a Hyprland session dying within 10-40s of resuming from suspend, intermittently, with no exit path recorded by either the session or lemurs.

Retry on ErrorKind::Interrupted in both the poll() and the non-blocking read() rather than tearing down the pipes.